### PR TITLE
Update Gradle wrapper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- fix distributionUrl for wrapper

## Testing
- `./gradlew --version`
- `./gradlew test --stacktrace` *(fails: Namespace not specified in module build file)*

------
https://chatgpt.com/codex/tasks/task_e_6848332686108321a521fa52291d93c3