### PR TITLE
Fix Gradle JVM path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64


### PR DESCRIPTION
## Summary
- use JDK 21 in `gradle.properties`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684839895df083219894abc3e658fda9