### PR TITLE
Configure Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
+org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
## Summary
- target Java 17 for Gradle builds

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483c72f9b88321abf52bc5bfa49f69